### PR TITLE
Allow usage with pytest v8+

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -34,7 +34,7 @@ keywords = [
 
 [tool.poetry.dependencies]
 python = "^3.8"
-pytest = "^7.3.2"
+pytest = ">=7.3.2"
 prysk = ">=0.15.0"
 
 


### PR DESCRIPTION
pytest had a major version step released at 2024-01-27, which currently isn't supported by pytest-prysk. Hence it is currently not possible to use the latest pytest and the latest pytest-prysk in the same enviroment.

This change loosens the version requirements in pyproject to allow pytest v8+ versions.